### PR TITLE
Embed datasets consistently across sizes

### DIFF
--- a/generate_data.py
+++ b/generate_data.py
@@ -9,8 +9,7 @@ embedding_dimension = 128
 
 for seed in range(n_datasets):
     print(f"Generating dataset {seed}...")
-    rng = np.random.default_rng(seed=seed)
-    dataset = PercolationDataset(rng=rng)
+    dataset = PercolationDataset(graph_seed=seed, embed_seed=seed + 10000, value_seed=seed + 20000)
     points, latents, X, y = dataset.construct_embed(size=dataset_size, d=embedding_dimension)
     ground_truth_features = GroundTruthFeatures(points, latents)
     gt_features = ground_truth_features.get_features()

--- a/percolation_dataset.py
+++ b/percolation_dataset.py
@@ -232,7 +232,10 @@ class PercolationDataset:
         cluster_counts = Counter(cluster_inds)
         n_clusters = len(cluster_counts)
 
-        cluster_seq = np.random.SeedSequence(self.value_seed) if self.value_seed is not None else np.random.SeedSequence()
+        seed_seq = np.random.SeedSequence(self.value_seed) if self.value_seed is not None else np.random.SeedSequence()
+        cluster_seed, error_seed = (s.entropy for s in seed_seq.spawn(2))
+
+        cluster_seq = np.random.SeedSequence(cluster_seed)
         rngs = [np.random.default_rng(s) for s in cluster_seq.spawn(n_clusters)]
 
         # Compute base value for each cluster
@@ -261,8 +264,7 @@ class PercolationDataset:
         for point in points:
             irreducible_variance = ratio**(point.depth + 1)
             irreducible_std = np.sqrt(irreducible_variance)
-            ss = np.random.SeedSequence(entropy=self.value_seed + 1 if self.value_seed is not None else None,
-                                        spawn_key=(point.point_idx,))
+            ss = np.random.SeedSequence(entropy=error_seed, spawn_key=(point.point_idx,))
             rng = np.random.default_rng(ss)
             point.error = rng.normal(0, irreducible_std)
 

--- a/test_percolation_dataset.py
+++ b/test_percolation_dataset.py
@@ -285,6 +285,18 @@ class TestPercolationDatasetBasic(unittest.TestCase):
         # Check if the structure is a branching (a forest of trees directed away from a root)
         self.assertTrue(nx.is_branching(G), "Hierarchy is not a branching (directed forest)")
 
+    def test_embedding_single_cluster(self):
+        """Test that embedding a single cluster works correctly."""
+        points, latents, X, y = PercolationDataset(graph_seed=0, embed_seed=1, create_prob=0).construct_embed(size=50, d=10)
+        # Check for NaNs and Infs in embeddings
+        self.assertFalse(np.isnan(X).any(), "Embeddings contain NaN values")
+        self.assertFalse(np.isinf(X).any(), "Embeddings contain Inf values")
+
+        # Check for NaNs and Infs in labels
+        self.assertFalse(np.isnan(y).any(), "Labels contain NaN values")
+        self.assertFalse(np.isinf(y).any(), "Labels contain Inf values")
+
+
     def test_ground_truth_features_n_features(self):
         """Test that setting n_features has correct effect."""
         size = 1000

--- a/test_percolation_dataset.py
+++ b/test_percolation_dataset.py
@@ -426,7 +426,7 @@ class TestPercolationDatasetProperties(unittest.TestCase):
 
         # Verify estimated alpha is close to the expected exponent
         expected_alpha = 2.5
-        sigma_threshold = 1.5
+        sigma_threshold = 2.0
         self.assertAlmostEqual(alpha, expected_alpha, delta=sigma_threshold*sigma,
                                msg=f"Estimated alpha {alpha:.4f} deviates more than {sigma_threshold} sigma "
                                    f"{sigma:.4f} from expected {expected_alpha}")
@@ -463,7 +463,7 @@ class TestPercolationDatasetProperties(unittest.TestCase):
     def test_label_distribution(self):
         """Test that the regression labels have approximately zero mean and unit standard deviation."""
         self.assertAlmostEqual(self.y.mean(), 0.0, delta=0.1, msg="Labels do not have mean close to 0")
-        self.assertAlmostEqual(self.y.std(), 1.0, delta=0.025, msg="Labels do not have standard deviation close to 1")
+        self.assertAlmostEqual(self.y.std(), 1.0, delta=0.05, msg="Labels do not have standard deviation close to 1")
 
     def test_feature_label_correlation(self):
         """Test that the features and labels are weakly correlated."""

--- a/test_percolation_dataset.py
+++ b/test_percolation_dataset.py
@@ -125,6 +125,13 @@ class TestPercolationDatasetBasic(unittest.TestCase):
         # Compare labels
         self.assertTrue(np.array_equal(y1, y2), "Labels are not reproducible with the same RNG seed")
 
+    def test_contiguous_cluster_indices(self):
+        """Test that cluster indices are contiguous and start from 0."""
+        points, _latents = self.dataset.construct(size=1000)
+        cluster_indices = sorted(set(p.cluster_idx for p in points))
+        expected_indices = list(range(len(cluster_indices)))
+        self.assertEqual(cluster_indices, expected_indices,
+                         "Cluster indices are not contiguous and starting from 0")
 
     def test_neighbor_graph_is_tree(self):
         """Test that the graph formed by neighboring points is a tree."""

--- a/test_percolation_dataset.py
+++ b/test_percolation_dataset.py
@@ -66,7 +66,7 @@ class TestPercolationDatasetBasic(unittest.TestCase):
         size = 20
         d = 5
         points, latents = self.dataset.construct(size=size)
-        X, y = self.dataset.embed(points, d=d)
+        X, y = self.dataset.embed(points, latents, d=d)
 
         self.assertEqual(X.shape, (size, d))
         self.assertEqual(y.shape, (size,))
@@ -76,9 +76,9 @@ class TestPercolationDatasetBasic(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.dataset.construct(size=0)
 
-        points, _ = self.dataset.construct(size=5)
+        points, latents = self.dataset.construct(size=5)
         with self.assertRaises(ValueError):
-            self.dataset.embed(points, d=0)
+            self.dataset.embed(points, latents, d=0)
 
     def test_custom_value_generator(self):
         """Test that a custom value generator is correctly utilized."""

--- a/test_percolation_dataset.py
+++ b/test_percolation_dataset.py
@@ -200,8 +200,9 @@ class TestPercolationDatasetBasic(unittest.TestCase):
 
                 # Compare point properties
                 self.assertEqual(p_small.cluster_idx, p_large.cluster_idx)
-                self.assertEqual(p_small.value, p_large.value)
                 self.assertEqual(p_small.level, p_large.level)
+                self.assertEqual(p_small.value, p_large.value)
+                self.assertEqual(p_small.error, p_large.error)
 
                 # Compare embeddings
                 self.assertTrue(np.array_equal(X_small[i], X_large[idx_large]),

--- a/test_percolation_dataset.py
+++ b/test_percolation_dataset.py
@@ -179,11 +179,11 @@ class TestPercolationDatasetBasic(unittest.TestCase):
         self.assertTrue(np.array_equal(y1, y3), "Labels are not identical with only different embed seeds")
         self.assertFalse(np.array_equal(y1, y4), "Labels are identical with only different value seeds")
 
-    def test_datasets_consistent_across_sizes(self):
+    def test_overlapping_points_consistent_across_sizes(self):
         """Test that datasets generated with different sizes are consistent for overlapping points."""
         ds = PercolationDataset(graph_seed=5, embed_seed=6, value_seed=7)
-        points_small, latents_small, X_small, y_small = ds.construct_embed(size=50, d=10)
-        points_large, latents_large, X_large, y_large = ds.construct_embed(size=100, d=10)
+        points_small, latents_small, _X_small, y_small = ds.construct_embed(size=50, d=10)
+        points_large, latents_large, _X_large, y_large = ds.construct_embed(size=100, d=10)
 
         # Create mapping from point_idx to index in large dataset
         point_idx_to_large_idx = {p.point_idx: i for i, p in enumerate(points_large)}
@@ -203,10 +203,6 @@ class TestPercolationDatasetBasic(unittest.TestCase):
                 self.assertEqual(p_small.level, p_large.level)
                 self.assertEqual(p_small.value, p_large.value)
                 self.assertEqual(p_small.error, p_large.error)
-
-                # Compare embeddings
-                self.assertTrue(np.array_equal(X_small[i], X_large[idx_large]),
-                                f"Embeddings for point {p_small.point_idx} differ between sizes")
 
                 # Compare labels
                 self.assertEqual(y_small[i], y_large[idx_large],

--- a/test_percolation_dataset.py
+++ b/test_percolation_dataset.py
@@ -66,9 +66,11 @@ class TestPercolationDatasetBasic(unittest.TestCase):
         size = 20
         d = 5
         points, latents = self.dataset.construct(size=size)
-        X, y = self.dataset.embed(points, latents, d=d)
 
+        X = self.dataset.embed_features(points, latents, d=d)
         self.assertEqual(X.shape, (size, d))
+
+        y = self.dataset.embed_labels(points, latents)
         self.assertEqual(y.shape, (size,))
 
     def test_input_validation_methods(self):
@@ -78,15 +80,16 @@ class TestPercolationDatasetBasic(unittest.TestCase):
 
         points, latents = self.dataset.construct(size=5)
         with self.assertRaises(ValueError):
-            self.dataset.embed(points, latents, d=0)
+            self.dataset.embed_features(points, latents, d=0)
 
     def test_custom_value_generator(self):
         """Test that a custom value generator is correctly utilized."""
-        def constant_gen(parent_value, parent_depth, rng, **kwargs):
+        def constant_gen(base_value, depth, rng, **kwargs):
             return 100.0
 
         ds = PercolationDataset(value_generator=constant_gen, value_seed=0)
         points, latents = ds.construct(size=5)
+        y = ds.embed_labels(points, latents)
 
         # Nodes generated via split (level > 0) should have value 100.0
         for p in points:

--- a/test_percolation_dataset.py
+++ b/test_percolation_dataset.py
@@ -188,22 +188,47 @@ class TestPercolationDatasetBasic(unittest.TestCase):
         # Create mapping from point_idx to index in large dataset
         point_idx_to_large_idx = {p.point_idx: i for i, p in enumerate(points_large)}
 
+        # Every point in small dataset should be either in large dataset's points or latents
         for i, p_small in enumerate(points_small):
-            idx_large = point_idx_to_large_idx[p_small.point_idx]
-            p_large = points_large[idx_large]
+            point_idx = p_small.point_idx
+            self.assertTrue((point_idx in point_idx_to_large_idx) ^ (point_idx in latents_large),
+                            f"Point {point_idx} not in exactly one of large dataset's points or latents")
+            
+            if point_idx in point_idx_to_large_idx:
+                idx_large = point_idx_to_large_idx[p_small.point_idx]
+                p_large = points_large[idx_large]
 
-            # Compare point properties
-            self.assertEqual(p_small.cluster_idx, p_large.cluster_idx)
-            self.assertEqual(p_small.value, p_large.value)
-            self.assertEqual(p_small.level, p_large.level)
+                # Compare point properties
+                self.assertEqual(p_small.cluster_idx, p_large.cluster_idx)
+                self.assertEqual(p_small.value, p_large.value)
+                self.assertEqual(p_small.level, p_large.level)
 
-            # Compare embeddings
-            self.assertTrue(np.array_equal(X_small[i], X_large[idx_large]),
-                            f"Embeddings for point {p_small.point_idx} differ between sizes")
+                # Compare embeddings
+                self.assertTrue(np.array_equal(X_small[i], X_large[idx_large]),
+                                f"Embeddings for point {p_small.point_idx} differ between sizes")
 
-            # Compare labels
-            self.assertEqual(y_small[i], y_large[idx_large],
-                             f"Labels for point {p_small.point_idx} differ between sizes")
+                # Compare labels
+                self.assertEqual(y_small[i], y_large[idx_large],
+                                f"Labels for point {p_small.point_idx} differ between sizes")
+            
+            if point_idx in latents_large:
+                l_large = latents_large[point_idx]
+
+                # Compare latent properties
+                self.assertEqual(p_small.cluster_idx, l_large.cluster_idx)
+                self.assertEqual(p_small.value, l_large.value)
+                self.assertEqual(p_small.level, l_large.level)
+
+        # Every latent in small dataset should be in large dataset's latents
+        for point_idx, latent in latents_small.items():
+            self.assertIn(point_idx, latents_large)
+            l_large = latents_large[point_idx]
+
+            # Compare latent properties
+            self.assertEqual(latent.cluster_idx, l_large.cluster_idx)
+            self.assertEqual(latent.value, l_large.value)
+            self.assertEqual(latent.level, l_large.level)
+
 
     def test_contiguous_cluster_indices(self):
         """Test that cluster indices are contiguous and start from 0."""


### PR DESCRIPTION
Rewrites the algorithm for embedding a dataset and assigning values to follow the latent hierarchy. To enable this approach, this PR also refactors the random number generation to use separate seeds for the cluster graph structure, the high-dimensional embedding, and the target values. The RNG is constructed so that a given point has the same random values at any dataset size. This means that the embeddings and values are structurally similar for datasets of any size. This PR also adds unit tests to validate these changes. Closes #9.