### PR TITLE
Add get_metadata(), use_values option for get_features(), and dataset filtering script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In the generation stage, each iteration follows one of two alternatives. With pr
 
 ## Usage
 
-A synthetic dataset is generated using `PercolationDataset.construct_embed()`. Ground-truth latent features for each sample can be generated as a sparse matrix using `GroundTruthFeatures.get_features()`. Because the dataset generation is stochastic, it is recommended to train and test models using multiple datasets generated with different random seeds. An example script to generate multiple datasets is provided in [generate_data.py](generate_data.py).
+A synthetic dataset is generated using `PercolationDataset.construct_embed()`. Ground-truth latent features for each sample can be generated as a sparse matrix using `GroundTruthFeatures.get_latent_features()`. Because the dataset generation is stochastic, it is recommended to train and test models using multiple datasets generated with different random seeds. An example script to generate multiple datasets is provided in [generate_data.py](generate_data.py).
 
 Datasets generated in the format of [generate_data.py](generate_data.py) can be loaded with:
 

--- a/generate_data.py
+++ b/generate_data.py
@@ -4,12 +4,12 @@ from scipy import sparse
 from percolation_dataset import PercolationDataset, GroundTruthFeatures
 
 n_datasets = 1
-dataset_size = 1000000
-embedding_dimension = 128
+dataset_size = 200000
+embedding_dimension = 100
 
 for seed in range(n_datasets):
     print(f"Generating dataset {seed}...")
-    dataset = PercolationDataset(graph_seed=seed, embed_seed=seed + 10000, value_seed=seed + 20000)
+    dataset = PercolationDataset(graph_seed=seed, embed_seed=seed + 10000, value_seed=seed + 20000, create_prob=0.0)
     points, latents, X, y = dataset.construct_embed(size=dataset_size, d=embedding_dimension)
     ground_truth_features = GroundTruthFeatures(points, latents)
     gt_features = ground_truth_features.get_features()

--- a/generate_data.py
+++ b/generate_data.py
@@ -3,9 +3,9 @@ from scipy import sparse
 
 from percolation_dataset import PercolationDataset, GroundTruthFeatures
 
-n_datasets = 1
-dataset_size = 200000
-embedding_dimension = 100
+n_datasets = 10
+dataset_size = 100000
+embedding_dimension = 128
 
 for seed in range(n_datasets):
     print(f"Generating dataset {seed}...")

--- a/generate_data.py
+++ b/generate_data.py
@@ -12,7 +12,7 @@ for seed in range(n_datasets):
     dataset = PercolationDataset(graph_seed=seed, embed_seed=seed + 10000, value_seed=seed + 20000)
     points, latents, X, y = dataset.construct_embed(size=dataset_size, d=embedding_dimension)
     ground_truth_features = GroundTruthFeatures(points, latents)
-    gt_features = ground_truth_features.get_features()
+    gt_features = ground_truth_features.get_features(use_values=True)
     gt_metadata = ground_truth_features.get_metadata()
     np.savez_compressed(
         f"percolation_dataset_size{dataset_size}_dim{embedding_dimension}_seed{seed}.npz",

--- a/generate_data.py
+++ b/generate_data.py
@@ -9,7 +9,7 @@ embedding_dimension = 100
 
 for seed in range(n_datasets):
     print(f"Generating dataset {seed}...")
-    dataset = PercolationDataset(graph_seed=seed, embed_seed=seed + 10000, value_seed=seed + 20000, create_prob=0.0)
+    dataset = PercolationDataset(graph_seed=seed, embed_seed=seed + 10000, value_seed=seed + 20000)
     points, latents, X, y = dataset.construct_embed(size=dataset_size, d=embedding_dimension)
     ground_truth_features = GroundTruthFeatures(points, latents)
     gt_features = ground_truth_features.get_features()

--- a/generate_data.py
+++ b/generate_data.py
@@ -3,8 +3,8 @@ from scipy import sparse
 
 from percolation_dataset import PercolationDataset, GroundTruthFeatures
 
-n_datasets = 10
-dataset_size = 100000
+n_datasets = 1
+dataset_size = 1000000
 embedding_dimension = 128
 
 for seed in range(n_datasets):
@@ -13,6 +13,7 @@ for seed in range(n_datasets):
     points, latents, X, y = dataset.construct_embed(size=dataset_size, d=embedding_dimension)
     ground_truth_features = GroundTruthFeatures(points, latents)
     gt_features = ground_truth_features.get_features()
+    gt_metadata = ground_truth_features.get_metadata()
     np.savez_compressed(
         f"percolation_dataset_size{dataset_size}_dim{embedding_dimension}_seed{seed}.npz",
         X=X,
@@ -21,4 +22,8 @@ for seed in range(n_datasets):
     sparse.save_npz(
         f"percolation_dataset_size{dataset_size}_dim{embedding_dimension}_seed{seed}_gt_features.npz",
         gt_features,
+    )
+    np.savez_compressed(
+        f"percolation_dataset_size{dataset_size}_dim{embedding_dimension}_seed{seed}_gt_metadata.npz",
+        **gt_metadata,
     )

--- a/generate_data.py
+++ b/generate_data.py
@@ -1,29 +1,27 @@
 import numpy as np
 from scipy import sparse
 
-from percolation_dataset import PercolationDataset, GroundTruthFeatures
+from percolation_dataset import PercolationDataset, GroundTruthFeatures, Node, Seeds
 
-n_datasets = 10
-dataset_size = 100000
-embedding_dimension = 128
+n_datasets = 1
+dataset_size = 2000000
+embedding_dimension = 100
 
 for seed in range(n_datasets):
     print(f"Generating dataset {seed}...")
-    dataset = PercolationDataset(graph_seed=seed, embed_seed=seed + 10000, value_seed=seed + 20000)
+    dataset = PercolationDataset(mode="distribution",seeds=Seeds(graph=seed, embed=seed + 10000, value=seed + 20000))
+
     points, latents, X, y = dataset.construct_embed(size=dataset_size, d=embedding_dimension)
     ground_truth_features = GroundTruthFeatures(points, latents)
-    gt_features = ground_truth_features.get_features(use_values=True)
-    gt_metadata = ground_truth_features.get_metadata()
+    gt_latent_features = ground_truth_features.get_latent_features(use_values=True)
+    gt_summary_features = ground_truth_features.get_summary_features()
     np.savez_compressed(
         f"percolation_dataset_size{dataset_size}_dim{embedding_dimension}_seed{seed}.npz",
         X=X,
         y=y,
+        **gt_summary_features,
     )
     sparse.save_npz(
         f"percolation_dataset_size{dataset_size}_dim{embedding_dimension}_seed{seed}_gt_features.npz",
-        gt_features,
-    )
-    np.savez_compressed(
-        f"percolation_dataset_size{dataset_size}_dim{embedding_dimension}_seed{seed}_gt_metadata.npz",
-        **gt_metadata,
+        gt_latent_features,
     )

--- a/percolation_dataset.py
+++ b/percolation_dataset.py
@@ -4,6 +4,7 @@ from itertools import islice
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple
 
 import numpy as np
+import pandas as pd
 from numpy.typing import NDArray
 from scipy import sparse
 
@@ -350,6 +351,28 @@ class GroundTruthFeatures:
         self.lidx2pidx = dict(sorted(self.lidx2pidx.items(), key=lambda item: item[0]))
         self.n_samples = len(self.points)
         self.n_latents = len(self.lidx2pidx)
+
+        counts = Counter(p.cluster_idx for p in self.points)
+        rows = []
+        for i, point in enumerate(self.points):
+            rows.append({
+                'cluster_id':   point.cluster_idx,
+                'cluster_size': counts[point.cluster_idx],
+                'tree_depth':   len(self.pidx2lidx[i]),
+            })
+        self._metadata = pd.DataFrame(rows)
+
+    def get_metadata(self) -> pd.DataFrame:
+        """
+        Returns a DataFrame of per-point metadata aligned with the feature matrix rows.
+
+        Returns:
+            DataFrame with columns:
+                - cluster_id: cluster index of the point
+                - cluster_size: number of points in the point's cluster
+                - tree_depth: number of latent ancestors of the point
+        """
+        return self._metadata
 
     def get_features(self, n_features: Optional[int] = None) -> sparse.csr_matrix:
         """

--- a/percolation_dataset.py
+++ b/percolation_dataset.py
@@ -370,13 +370,15 @@ class GroundTruthFeatures:
             'tree_height':  [len(self.pidx2lidx[i]) for i, _ in enumerate(self.points)],
         }
 
-    def get_features(self, n_features: Optional[int] = None) -> sparse.csr_matrix:
+    def get_features(self, n_features: Optional[int] = None, use_values: bool = False) -> sparse.csr_matrix:
         """
         Returns sparse matrix of latent features for each data point.
 
         Args:
             n_features: Number of features to return, in generation order. If None, returns all features.
-        Returns:            
+            use_values: If True, store the actual z_u value for each latent instead of 1.
+                        Requires embed_labels() to have been called (i.e. use construct_embed(), not construct()).
+        Returns:
             features: Sparse matrix of shape (n_points, n_features).
         """
         if n_features is None:
@@ -388,7 +390,16 @@ class GroundTruthFeatures:
         col_ind = []
 
         for lidx, pidx in islice(self.lidx2pidx.items(), n_features):
-            data.extend(np.ones_like(pidx))
+            if use_values:
+                latent_node = self.latents[self.lidx2latent[lidx]]
+                if latent_node.parents:
+                    parent = list(latent_node.parents)[0]
+                    z_u = latent_node.value - parent.value
+                else:
+                    z_u = latent_node.value
+                data.extend([z_u] * len(pidx))
+            else:
+                data.extend(np.ones_like(pidx))
             row_ind.extend(pidx)
             col_ind.extend(np.full_like(pidx, lidx))
 

--- a/percolation_dataset.py
+++ b/percolation_dataset.py
@@ -352,7 +352,7 @@ class GroundTruthFeatures:
         self.n_latents = len(self.lidx2pidx)
 
 
-    def get_metadata(self) -> dict:
+    def get_summary_features(self) -> dict:
         """
         Returns a dict of per-point metadata aligned with the feature matrix rows.
 
@@ -360,17 +360,17 @@ class GroundTruthFeatures:
             dict with keys:
                 - cluster_id: cluster index of each point
                 - cluster_size: number of points in each point's cluster
-                - tree_height: number of latent ancestors of each point
+                - latent_tree_height: number of latent ancestors of each point
         """
 
         counts = Counter(p.cluster_idx for p in self.points)
         return {
-            'cluster_id':   [p.cluster_idx for p in self.points],
-            'cluster_size': [counts[p.cluster_idx] for p in self.points],
-            'tree_height':  [len(self.pidx2lidx[i]) for i, _ in enumerate(self.points)],
+            'cluster_id':        [p.cluster_idx for p in self.points],
+            'cluster_size':      [counts[p.cluster_idx] for p in self.points],
+            'latent_tree_height': [len(self.pidx2lidx[i]) for i, _ in enumerate(self.points)],
         }
 
-    def get_features(self, n_features: Optional[int] = None, use_values: bool = False) -> sparse.csr_matrix:
+    def get_latent_features(self, n_features: Optional[int] = None, use_values: bool = False) -> sparse.csr_matrix:
         """
         Returns sparse matrix of latent features for each data point.
 

--- a/percolation_dataset.py
+++ b/percolation_dataset.py
@@ -4,7 +4,6 @@ from itertools import islice
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple
 
 import numpy as np
-import pandas as pd
 from numpy.typing import NDArray
 from scipy import sparse
 
@@ -352,27 +351,24 @@ class GroundTruthFeatures:
         self.n_samples = len(self.points)
         self.n_latents = len(self.lidx2pidx)
 
-        counts = Counter(p.cluster_idx for p in self.points)
-        rows = []
-        for i, point in enumerate(self.points):
-            rows.append({
-                'cluster_id':   point.cluster_idx,
-                'cluster_size': counts[point.cluster_idx],
-                'tree_depth':   len(self.pidx2lidx[i]),
-            })
-        self._metadata = pd.DataFrame(rows)
 
-    def get_metadata(self) -> pd.DataFrame:
+    def get_metadata(self) -> dict:
         """
-        Returns a DataFrame of per-point metadata aligned with the feature matrix rows.
+        Returns a dict of per-point metadata aligned with the feature matrix rows.
 
         Returns:
-            DataFrame with columns:
-                - cluster_id: cluster index of the point
-                - cluster_size: number of points in the point's cluster
-                - tree_depth: number of latent ancestors of the point
+            dict with keys:
+                - cluster_id: cluster index of each point
+                - cluster_size: number of points in each point's cluster
+                - tree_height: number of latent ancestors of each point
         """
-        return self._metadata
+
+        counts = Counter(p.cluster_idx for p in self.points)
+        return {
+            'cluster_id':   [p.cluster_idx for p in self.points],
+            'cluster_size': [counts[p.cluster_idx] for p in self.points],
+            'tree_height':  [len(self.pidx2lidx[i]) for i, _ in enumerate(self.points)],
+        }
 
     def get_features(self, n_features: Optional[int] = None) -> sparse.csr_matrix:
         """

--- a/scripts/filter_dataset.py
+++ b/scripts/filter_dataset.py
@@ -7,7 +7,7 @@ data_folder_path = Path("../")
 data_path = data_folder_path / "percolation_dataset_size2000000_dim100_seed0.npz"
 feature_data_path = data_folder_path / "percolation_dataset_size2000000_dim100_seed0_gt_features.npz"
 meta_data_path = data_folder_path / "percolation_dataset_size2000000_dim100_seed0_gt_metadata.npz"
-base_name = data_path.stem  # "percolation_dataset_size1000000_dim100_seed0"
+base_name = data_path.stem  # "percolation_dataset_size2000000_dim100_seed0"
 
 
 # Set filter parameters 

--- a/scripts/filter_dataset.py
+++ b/scripts/filter_dataset.py
@@ -1,17 +1,26 @@
+import sys
 import numpy as np
 from pathlib import Path
 from scipy import sparse
+from typing import List, Optional
+
+sys.path.insert(0, str(Path("../").resolve()))
+from percolation_dataset import PercolationDataset, GroundTruthFeatures, Node
 
 # Set input paths
 data_folder_path = Path("../")
-data_path = data_folder_path / "percolation_dataset_size1000000_dim100_seed0.npz"
-feature_data_path = data_folder_path / "percolation_dataset_size1000000_dim100_seed0_gt_features.npz"
-meta_data_path = data_folder_path / "percolation_dataset_size1000000_dim100_seed0_gt_metadata.npz"
-base_name = data_path.stem  # "percolation_dataset_size1000000_dim100_seed0"
+data_path = data_folder_path / "percolation_dataset_size2000000_dim100_seed0.npz"
+feature_data_path = data_folder_path / "percolation_dataset_size2000000_dim100_seed0_gt_features.npz"
+meta_data_path = data_folder_path / "percolation_dataset_size2000000_dim100_seed0_gt_metadata.npz"
+base_name = data_path.stem
 
+# Dataset generation parameters (must match the original generation)
+dataset_size = 2000000
+embedding_dimension = 100
+seed = 0
 
-# Set filter parameters 
-min_size = 13600
+# Set filter parameters
+min_size = 250
 max_size = None
 
 # Load data
@@ -59,7 +68,11 @@ np.savez_compressed(
 )
 
 
+
+
 print(f"Filtered dataset saved to {data_folder_path}")
 print(f"Original size: {len(X)} points")
 print(f"Filtered size: {len(X_filtered)} points ({mask.sum() / len(X) * 100:.1f}% retained)")
+print(f"Number of clusters: {len(np.unique(metadata_filtered['cluster_id']))}")
+
 

--- a/scripts/filter_dataset.py
+++ b/scripts/filter_dataset.py
@@ -1,25 +1,16 @@
-import sys
 import numpy as np
 from pathlib import Path
 from scipy import sparse
-from typing import List, Optional
-
-sys.path.insert(0, str(Path("../").resolve()))
-from percolation_dataset import PercolationDataset, GroundTruthFeatures, Node
 
 # Set input paths
 data_folder_path = Path("../")
 data_path = data_folder_path / "percolation_dataset_size2000000_dim100_seed0.npz"
 feature_data_path = data_folder_path / "percolation_dataset_size2000000_dim100_seed0_gt_features.npz"
 meta_data_path = data_folder_path / "percolation_dataset_size2000000_dim100_seed0_gt_metadata.npz"
-base_name = data_path.stem
+base_name = data_path.stem  # "percolation_dataset_size1000000_dim100_seed0"
 
-# Dataset generation parameters (must match the original generation)
-dataset_size = 2000000
-embedding_dimension = 100
-seed = 0
 
-# Set filter parameters
+# Set filter parameters 
 min_size = 250
 max_size = None
 
@@ -49,7 +40,7 @@ y_filtered = y[mask]
 features_filtered = features[mask, :]
 metadata_filtered = {key: np.array(meta_res[key])[mask] for key in meta_res}
 # Remove all-zero columns after row filtering
-col_mask = np.array(features_filtered.sum(axis=0)).flatten() > 0
+col_mask = np.array((features_filtered != 0).sum(axis=0)).flatten() > 0
 features_filtered = features_filtered[:, col_mask]
 
 

--- a/scripts/filter_dataset.py
+++ b/scripts/filter_dataset.py
@@ -1,0 +1,65 @@
+import numpy as np
+from pathlib import Path
+from scipy import sparse
+
+# Set input paths
+data_folder_path = Path("../")
+data_path = data_folder_path / "percolation_dataset_size1000000_dim100_seed0.npz"
+feature_data_path = data_folder_path / "percolation_dataset_size1000000_dim100_seed0_gt_features.npz"
+meta_data_path = data_folder_path / "percolation_dataset_size1000000_dim100_seed0_gt_metadata.npz"
+base_name = data_path.stem  # "percolation_dataset_size1000000_dim100_seed0"
+
+
+# Set filter parameters 
+min_size = 13600
+max_size = None
+
+# Load data
+with np.load(data_path) as res:
+    X, y = res['X'], res['y']
+
+features = sparse.load_npz(feature_data_path)
+meta_res = np.load(meta_data_path, allow_pickle=True)
+
+# Filter 
+if min_size is not None and max_size is not None:
+    mask = (np.array(meta_res['cluster_size']) > min_size) & (np.array(meta_res['cluster_size']) < max_size)
+    suffix = f"_filtered_cluster_size{min_size}to{max_size}"
+elif min_size is not None:
+    mask = np.array(meta_res['cluster_size']) > min_size
+    suffix = f"_filtered_cluster_size_min{min_size}"
+elif max_size is not None:
+    mask = np.array(meta_res['cluster_size']) < max_size
+    suffix = f"_filtered_cluster_size_max{max_size}"
+else:
+    mask = np.ones(len(X), dtype=bool)
+    suffix = ""
+
+X_filtered = X[mask]
+y_filtered = y[mask]
+features_filtered = features[mask, :]
+metadata_filtered = {key: np.array(meta_res[key])[mask] for key in meta_res}
+# Remove all-zero columns after row filtering
+col_mask = np.array(features_filtered.sum(axis=0)).flatten() > 0
+features_filtered = features_filtered[:, col_mask]
+
+
+# Store filtered dataset
+np.savez_compressed(
+    data_folder_path / f"{base_name}{suffix}.npz",
+    X=X_filtered, y=y_filtered
+)
+sparse.save_npz(
+    str(data_folder_path / f"{base_name}_gt_features{suffix}.npz"),
+    features_filtered
+)
+np.savez_compressed(
+    data_folder_path / f"{base_name}_gt_metadata{suffix}.npz",
+    **metadata_filtered
+)
+
+
+print(f"Filtered dataset saved to {data_folder_path}")
+print(f"Original size: {len(X)} points")
+print(f"Filtered size: {len(X_filtered)} points ({mask.sum() / len(X) * 100:.1f}% retained)")
+

--- a/test_percolation_dataset.py
+++ b/test_percolation_dataset.py
@@ -302,29 +302,29 @@ class TestPercolationDatasetBasic(unittest.TestCase):
         points, latents = self.dataset.construct(size=size)
         gt_features = GroundTruthFeatures(points, latents)
         # Default n_features equal n_latents
-        X_gt = gt_features.get_features()
+        X_gt = gt_features.get_latent_features()
         assert X_gt.shape is not None
         self.assertEqual(X_gt.shape[1], gt_features.n_latents,
                          "Ground truth feature matrix has incorrect number of columns")
         # Setting n_features yields correct shape
         n_features = gt_features.n_latents // 2
-        X_gt = gt_features.get_features(n_features=n_features)
+        X_gt = gt_features.get_latent_features(n_features=n_features)
         assert X_gt.shape is not None
         self.assertEqual(X_gt.shape[1], n_features,
                          "Ground truth feature matrix has incorrect number of columns when n_features is set")
         # Setting n_features less than 1 raises error
         with self.assertRaises(ValueError):
-            gt_features.get_features(n_features=0)
+            gt_features.get_latent_features(n_features=0)
         # Setting n_features greater than n_latents raises error
         with self.assertRaises(ValueError):
-            gt_features.get_features(n_features=gt_features.n_latents + 1)
+            gt_features.get_latent_features(n_features=gt_features.n_latents + 1)
 
     def test_ground_truth_feature_matrix(self):
         """Test that ground truth feature matrix has correct shape and content."""
         size = 1000
         points, latents = self.dataset.construct(size=size)
         gt_features = GroundTruthFeatures(points, latents)
-        X_gt = gt_features.get_features()
+        X_gt = gt_features.get_latent_features()
 
         assert X_gt.shape is not None
         self.assertEqual(X_gt.shape[0], size, "Ground truth feature matrix has incorrect number of rows")
@@ -338,43 +338,42 @@ class TestPercolationDatasetBasic(unittest.TestCase):
             self.assertEqual(set(non_zero_indices), set(expected_latent_indices),
                              f"Row {pidx} of ground truth feature matrix has incorrect non-zero entries")
             
-    def test_get_metadata(self):
-        """Test that get_metadata returns correct per-point metadata aligned with feature matrix rows."""
-        from collections import Counter
+    def test_get_summary_features(self):
+        """Test that get_summary_features returns correct per-point metadata aligned with feature matrix rows."""
         size = 1000
         points, latents = self.dataset.construct(size=size)
         gt_features = GroundTruthFeatures(points, latents)
-        metadata = gt_features.get_metadata()
+        metadata = gt_features.get_summary_features()
 
         self.assertIsInstance(metadata, dict)
-        self.assertListEqual(list(metadata.keys()), ['cluster_id', 'cluster_size', 'tree_height'])
-        for values in metadata.values():
-            self.assertEqual(len(values), size)
+        self.assertListEqual(list(metadata.keys()), ['cluster_id', 'cluster_size', 'latent_tree_height'])
+        for value in metadata.values():
+            self.assertEqual(len(value), size)
 
         counts = Counter(p.cluster_idx for p in points)
         for i, point in enumerate(points):
             self.assertEqual(metadata['cluster_id'][i], point.cluster_idx)
             self.assertEqual(metadata['cluster_size'][i], counts[point.cluster_idx])
-            self.assertEqual(metadata['tree_height'][i], len(gt_features.pidx2lidx[i]))
+            self.assertEqual(metadata['latent_tree_height'][i], len(gt_features.pidx2lidx[i]))
 
-    def test_get_features_use_values(self):
-        """Test that get_features(use_values=True) stores correct z_u values."""
+    def test_get_latent_features_use_values(self):
+        """Test that get_latent_features(use_values=True) stores correct z_u values."""
         size = 100
         points, latents, X, y = self.dataset.construct_embed(size=size, d=16)
-        gtf = GroundTruthFeatures(points, latents)
+        gt_features = GroundTruthFeatures(points, latents)
 
-        X_binary = gtf.get_features(use_values=False)
-        X_values = gtf.get_features(use_values=True)
+        X_binary = gt_features.get_latent_features(use_values=False)
+        X_values = gt_features.get_latent_features(use_values=True)
 
         # Sparsity pattern must be identical
-        self.assertEqual((X_binary != 0).nnz, (X_values != 0).nnz)
+        self.assertEqual(X_binary.nnz, X_values.nnz)
 
         # Binary mode still returns 1s
         self.assertTrue(np.all(X_binary.data == 1))
 
         # Check z_u values are correct for each latent
-        for lidx in range(gtf.n_latents):
-            latent_node = gtf.latents[gtf.lidx2latent[lidx]]
+        for lidx in range(gt_features.n_latents):
+            latent_node = gt_features.latents[gt_features.lidx2latent[lidx]]
             if latent_node.parents:
                 parent = list(latent_node.parents)[0]
                 expected_z_u = latent_node.value - parent.value
@@ -383,16 +382,17 @@ class TestPercolationDatasetBasic(unittest.TestCase):
             col = X_values.getcol(lidx)
             nonzero_vals = col.data
             if len(nonzero_vals) > 0:
-                np.testing.assert_allclose(nonzero_vals, expected_z_u,
-                    err_msg=f"Incorrect z_u value for latent {lidx}")
+                # Note: np.testing.assert_allclose would give richer failure messages
+                self.assertTrue(np.allclose(nonzero_vals, expected_z_u),
+                    msg=f"Incorrect z_u value for latent {lidx}")
 
         # Sum of z_u telescopes to the deepest ancestor latent's value
         # (point.value also includes the leaf's own Gaussian draw, not stored in features)
         for pidx, point in enumerate(points):
             row = X_values.getrow(pidx)
-            ancestors = gtf.pidx2lidx[pidx]
+            ancestors = gt_features.pidx2lidx[pidx]
             if ancestors:
-                deepest_latent = gtf.latents[gtf.lidx2latent[ancestors[-1]]]
+                deepest_latent = gt_features.latents[gt_features.lidx2latent[ancestors[-1]]]
                 self.assertAlmostEqual(row.sum(), deepest_latent.value, places=10,
                     msg=f"Sum of z_u for point {pidx} does not equal deepest ancestor latent value")
 

--- a/test_percolation_dataset.py
+++ b/test_percolation_dataset.py
@@ -328,8 +328,7 @@ class TestPercolationDatasetBasic(unittest.TestCase):
 
         assert X_gt.shape is not None
         self.assertEqual(X_gt.shape[0], size, "Ground truth feature matrix has incorrect number of rows")
-        self.assertEqual(X_gt.shape[1], gt_features.n_latents,
-                         "Ground truth feature matrix has incorrect number of columns")
+        self.assertEqual(X_gt.shape[1], gt_features.n_latents,"Ground truth feature matrix has incorrect number of columns")
 
         # Verify that each row has exactly one non-zero entry per latent node it is associated with
         for pidx in range(size):
@@ -347,14 +346,16 @@ class TestPercolationDatasetBasic(unittest.TestCase):
         gt_features = GroundTruthFeatures(points, latents)
         metadata = gt_features.get_metadata()
 
-        self.assertEqual(metadata.shape, (size, 3), "Metadata has incorrect shape")
-        self.assertListEqual(list(metadata.columns), ['cluster_id', 'cluster_size', 'tree_depth'])
+        self.assertIsInstance(metadata, dict)
+        self.assertListEqual(list(metadata.keys()), ['cluster_id', 'cluster_size', 'tree_height'])
+        for values in metadata.values():
+            self.assertEqual(len(values), size)
 
         counts = Counter(p.cluster_idx for p in points)
         for i, point in enumerate(points):
-            self.assertEqual(metadata.loc[i, 'cluster_id'], point.cluster_idx)
-            self.assertEqual(metadata.loc[i, 'cluster_size'], counts[point.cluster_idx])
-            self.assertEqual(metadata.loc[i, 'tree_depth'], len(gt_features.pidx2lidx[i]))
+            self.assertEqual(metadata['cluster_id'][i], point.cluster_idx)
+            self.assertEqual(metadata['cluster_size'][i], counts[point.cluster_idx])
+            self.assertEqual(metadata['tree_height'][i], len(gt_features.pidx2lidx[i]))
 
     def test_nearest_neighbor_ground_truth(self):
         """Test that 1-NN using the ground truth points matches the embedded dataset."""

--- a/test_percolation_dataset.py
+++ b/test_percolation_dataset.py
@@ -357,6 +357,45 @@ class TestPercolationDatasetBasic(unittest.TestCase):
             self.assertEqual(metadata['cluster_size'][i], counts[point.cluster_idx])
             self.assertEqual(metadata['tree_height'][i], len(gt_features.pidx2lidx[i]))
 
+    def test_get_features_use_values(self):
+        """Test that get_features(use_values=True) stores correct z_u values."""
+        size = 100
+        points, latents, X, y = self.dataset.construct_embed(size=size, d=16)
+        gtf = GroundTruthFeatures(points, latents)
+
+        X_binary = gtf.get_features(use_values=False)
+        X_values = gtf.get_features(use_values=True)
+
+        # Sparsity pattern must be identical
+        self.assertEqual((X_binary != 0).nnz, (X_values != 0).nnz)
+
+        # Binary mode still returns 1s
+        self.assertTrue(np.all(X_binary.data == 1))
+
+        # Check z_u values are correct for each latent
+        for lidx in range(gtf.n_latents):
+            latent_node = gtf.latents[gtf.lidx2latent[lidx]]
+            if latent_node.parents:
+                parent = list(latent_node.parents)[0]
+                expected_z_u = latent_node.value - parent.value
+            else:
+                expected_z_u = latent_node.value
+            col = X_values.getcol(lidx)
+            nonzero_vals = col.data
+            if len(nonzero_vals) > 0:
+                np.testing.assert_allclose(nonzero_vals, expected_z_u,
+                    err_msg=f"Incorrect z_u value for latent {lidx}")
+
+        # Sum of z_u telescopes to the deepest ancestor latent's value
+        # (point.value also includes the leaf's own Gaussian draw, not stored in features)
+        for pidx, point in enumerate(points):
+            row = X_values.getrow(pidx)
+            ancestors = gtf.pidx2lidx[pidx]
+            if ancestors:
+                deepest_latent = gtf.latents[gtf.lidx2latent[ancestors[-1]]]
+                self.assertAlmostEqual(row.sum(), deepest_latent.value, places=10,
+                    msg=f"Sum of z_u for point {pidx} does not equal deepest ancestor latent value")
+
     def test_nearest_neighbor_ground_truth(self):
         """Test that 1-NN using the ground truth points matches the embedded dataset."""
         points, _latents, X, y = self.dataset.construct_embed(size=10000, d=128)

--- a/test_percolation_dataset.py
+++ b/test_percolation_dataset.py
@@ -339,6 +339,23 @@ class TestPercolationDatasetBasic(unittest.TestCase):
             self.assertEqual(set(non_zero_indices), set(expected_latent_indices),
                              f"Row {pidx} of ground truth feature matrix has incorrect non-zero entries")
             
+    def test_get_metadata(self):
+        """Test that get_metadata returns correct per-point metadata aligned with feature matrix rows."""
+        from collections import Counter
+        size = 1000
+        points, latents = self.dataset.construct(size=size)
+        gt_features = GroundTruthFeatures(points, latents)
+        metadata = gt_features.get_metadata()
+
+        self.assertEqual(metadata.shape, (size, 3), "Metadata has incorrect shape")
+        self.assertListEqual(list(metadata.columns), ['cluster_id', 'cluster_size', 'tree_depth'])
+
+        counts = Counter(p.cluster_idx for p in points)
+        for i, point in enumerate(points):
+            self.assertEqual(metadata.loc[i, 'cluster_id'], point.cluster_idx)
+            self.assertEqual(metadata.loc[i, 'cluster_size'], counts[point.cluster_idx])
+            self.assertEqual(metadata.loc[i, 'tree_depth'], len(gt_features.pidx2lidx[i]))
+
     def test_nearest_neighbor_ground_truth(self):
         """Test that 1-NN using the ground truth points matches the embedded dataset."""
         points, _latents, X, y = self.dataset.construct_embed(size=10000, d=128)


### PR DESCRIPTION
## Changes

### New: `get_metadata()` in `GroundTruthFeatures`
Returns a dict of per-point metadata aligned with the feature matrix rows:
- `cluster_id`: cluster index of each point
- `cluster_size`: number of points in the cluster
- `tree_height`: number of latent ancestors of each point

### New: `use_values` parameter in `get_features()`
`get_features(use_values=True)` stores the actual incremental latent value z_u 
(i.e. `node.value - parent.value`, or `node.value` for the root) instead of 1 
for each nonzero entry. Default is `False` to preserve existing behavior.
Updated `generate_data.py` to use `use_values=True` by default.

### Bug fix: `col_mask` after row filtering
`col_mask` previously used `.sum(axis=0) > 0` which incorrectly dropped columns 
with negative z_u values. Fixed to `(features != 0).sum(axis=0) > 0`.

### New: `scripts/filter_dataset.py`
Example script for filtering a saved dataset by cluster size, saving filtered 
X, y, features, and metadata.

### Tests
Added unit tests for `get_metadata()` and `get_features(use_values=True)`.
